### PR TITLE
Implement voter restrictions for voting links

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,7 +249,27 @@
     }
 
     .voter-item {
-      transition: transform 0.2s, box-shadow 0.2s, opacity 0.2s;
+      transition: transform 0.2s, box-shadow 0.2s, opacity 0.2s, background-color 0.5s, color 0.5s;
+    }
+
+    .voter-item.constraint {
+      background-color: var(--primary-color);
+      color: var(--light-text);
+    }
+
+    .totals.selection-active {
+      background-color: var(--primary-color);
+      color: var(--light-text);
+    }
+
+    .totals.selection-active .total-label {
+      color: var(--light-text);
+    }
+
+    .totals.selection-active .total-value {
+      background-color: white;
+      padding: 2px 6px;
+      border-radius: 4px;
     }
 
     /* Only show grab cursor in edit mode */
@@ -282,7 +302,7 @@
 </head>
 
 <body>
-  <div x-data="votingApp()" x-init="initApp()">
+  <div x-data="votingApp()" x-init="initApp()" @click="clearSelection()">
     <header>
       <div style="display: flex; align-items: center; position: relative;">
         <input
@@ -333,6 +353,7 @@
             </svg>
           </span>
         </button>
+        <span x-show="selectedVoters.length > 0" style="color: white; margin-left: 5px; font-size: 0.8rem;" x-text="selectedVoters.map(i => voters[i].name).join(', ')"></span>
 
         <button
           @click="toggleEditMode()"
@@ -357,7 +378,7 @@
     <div class="container">
       <div class="voter-list">
         <template x-for="(voter, index) in voters" :key="index">
-          <div class="voter-item" 
+          <div class="voter-item"
                :draggable="editMode"
                @dragstart="editMode && dragStart($event, index)"
                @dragover.prevent="editMode && dragOver($event, index)"
@@ -365,7 +386,8 @@
                @dragleave="editMode && dragLeave($event)"
                @drop.prevent="editMode && drop($event, index)"
                @dragend="editMode && dragEnd($event)"
-               :class="{ 'dragging': draggedIndex === index }"
+               @click.stop="handleVoterClick($event, index)"
+               :class="{ 'dragging': draggedIndex === index, 'constraint': (selectedVoters.includes(index) && !isPeer) || (isPeer && allowedVoters && !allowedVoters.includes(index)) }"
           >
             <div class="voter-info">
               <input
@@ -506,7 +528,7 @@
       </div>
     </div>
 
-    <div class="totals" x-show="!editMode">
+    <div class="totals" x-show="!editMode" :class="{ 'selection-active': selectedVoters.length > 0 && !isPeer }">
       <div class="total-item yeah">
         <div class="total-label">Yeah</div>
         <div class="total-value" x-text="getTotalByVote('yeah')"></div>
@@ -530,6 +552,8 @@
         editMode: true, // Start with edit mode enabled
         showCoffeeBanner: true, // Control visibility of the coffee banner
         draggedIndex: null, // Track which voter is being dragged
+        selectedVoters: [], // Selected voters for link generation
+        allowedVoters: null, // Voting restriction when joining via link
 
         // WebRTC properties
         peer: null,
@@ -564,6 +588,7 @@
               // Update previousGroupTitle to match
               this.previousGroupTitle = this.groupTitle;
               this.masterId = votingConfig.masterId;
+              this.allowedVoters = votingConfig.allowedVoters || null;
 
               // Initialize peer connection
               this.initPeer(true);
@@ -827,6 +852,9 @@
             groupTitle: this.groupTitle,
             masterId: this.peerId
           };
+          if (this.selectedVoters.length > 0) {
+            votingConfig.allowedVoters = this.selectedVoters;
+          }
 
           // Encode the configuration
           const encodedConfig = btoa(JSON.stringify(votingConfig));
@@ -852,9 +880,9 @@
             });
         },
 
-        normalInit(groupParam) {
-          if (groupParam) {
-            this.groupTitle = decodeURIComponent(groupParam);
+       normalInit(groupParam) {
+         if (groupParam) {
+           this.groupTitle = decodeURIComponent(groupParam);
             // Update previousGroupTitle to match
             this.previousGroupTitle = this.groupTitle;
             this.loadData();
@@ -873,9 +901,11 @@
             this.previousGroupTitle = this.groupTitle;
             this.updateGroupTitle();
             // If no voting group, default to edit enabled
-            this.editMode = true;
-          }
-        },
+           this.editMode = true;
+         }
+          // Clear any voting restrictions
+          this.allowedVoters = null;
+       },
 
         // Store the previous title to check for changes
         previousGroupTitle: '',
@@ -938,7 +968,24 @@
           }
         },
 
+        handleVoterClick(event, index) {
+          if (this.editMode || this.isPeer) return;
+          if (event.target.closest('.vote-option')) return;
+          if (this.selectedVoters.includes(index)) {
+            this.selectedVoters = this.selectedVoters.filter(i => i !== index);
+          } else {
+            this.selectedVoters.push(index);
+          }
+        },
+
+        clearSelection() {
+          this.selectedVoters = [];
+        },
+
         setVote(index, vote) {
+          if (this.isPeer && this.allowedVoters && !this.allowedVoters.includes(index)) {
+            return;
+          }
           this.voters[index].vote = vote;
           this.saveData();
 
@@ -962,11 +1009,20 @@
           }
         },
 
-        getTotalByVote(voteType) {
-          return this.voters
-            .filter(voter => voter.vote === voteType)
+       getTotalByVote(voteType) {
+          let indexes;
+          if (this.isPeer && this.allowedVoters && this.allowedVoters.length > 0) {
+            indexes = this.allowedVoters;
+          } else if (!this.isPeer && this.selectedVoters.length > 0) {
+            indexes = this.selectedVoters;
+          } else {
+            indexes = this.voters.map((_, i) => i);
+          }
+          return indexes
+            .map(i => this.voters[i])
+            .filter(voter => voter && voter.vote === voteType)
             .reduce((sum, voter) => sum + (voter.count || 0), 0);
-        },
+       },
 
         saveData() {
           if (!this.groupTitle) return;


### PR DESCRIPTION
## Summary
- allow session creator to select voters for restricted voting links
- show selected voter names near the voting link button
- visually indicate selected or restricted voters and totals bar
- generate vote links with allowed voter indices
- prevent peers from voting for unpermitted voters and update total calculation

## Testing
- `git status --short`