### PR TITLE
Implement faster selection and cleaner vote display

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,7 @@
       --danger-color: #ff4d4f;
       --success-color: #52c41a;
       --neutral-color: #d9d9d9;
+      --selection-color: #ffe4a1;
       --text-color: #333;
       --light-text: #fff;
       --border-radius: 8px;
@@ -109,6 +110,16 @@
       border-radius: 4px;
     }
 
+    .voter-name[readonly], .voter-count[readonly] {
+      pointer-events: none;
+      cursor: default;
+    }
+
+    .voter-name[readonly]:focus, .voter-count[readonly]:focus {
+      outline: none;
+      background: transparent;
+    }
+
     .voter-name {
       font-weight: bold;
       min-width: 120px;
@@ -131,7 +142,7 @@
       -moz-appearance: textfield;
     }
 
-    .voter-name:focus, .voter-count:focus {
+    .voter-name:not([readonly]):focus, .voter-count:not([readonly]):focus {
       outline: 2px solid var(--primary-color);
       background-color: var(--secondary-color);
     }
@@ -207,6 +218,7 @@
       display: flex;
       justify-content: space-around;
       align-items: center;
+      transition: background-color 0.25s, color 0.25s;
     }
 
     .total-item {
@@ -249,7 +261,27 @@
     }
 
     .voter-item {
-      transition: transform 0.2s, box-shadow 0.2s, opacity 0.2s;
+      transition: transform 0.2s, box-shadow 0.2s, opacity 0.2s, background-color 0.25s, color 0.25s;
+    }
+
+    .voter-item.constraint {
+      background-color: var(--selection-color);
+      color: var(--text-color);
+    }
+
+    .totals.selection-active {
+      background-color: var(--selection-color);
+      color: var(--text-color);
+    }
+
+    .totals.selection-active .total-label {
+      color: var(--light-text);
+    }
+
+    .totals.selection-active .total-value {
+      background-color: white;
+      padding: 2px 6px;
+      border-radius: 4px;
     }
 
     /* Only show grab cursor in edit mode */
@@ -282,7 +314,7 @@
 </head>
 
 <body>
-  <div x-data="votingApp()" x-init="initApp()">
+  <div x-data="votingApp()" x-init="initApp()" @click="clearSelection()">
     <header>
       <div style="display: flex; align-items: center; position: relative;">
         <input
@@ -333,6 +365,7 @@
             </svg>
           </span>
         </button>
+        <span x-show="selectedVoters.length > 0" style="color: white; margin-left: 5px; font-size: 0.8rem; white-space: nowrap;" x-text="selectedVoters.map(i => voters[i].name || ('Voter ' + (i + 1))).join(', ')"></span>
 
         <button
           @click="toggleEditMode()"
@@ -357,7 +390,7 @@
     <div class="container">
       <div class="voter-list">
         <template x-for="(voter, index) in voters" :key="index">
-          <div class="voter-item" 
+          <div class="voter-item"
                :draggable="editMode"
                @dragstart="editMode && dragStart($event, index)"
                @dragover.prevent="editMode && dragOver($event, index)"
@@ -365,22 +398,25 @@
                @dragleave="editMode && dragLeave($event)"
                @drop.prevent="editMode && drop($event, index)"
                @dragend="editMode && dragEnd($event)"
-               :class="{ 'dragging': draggedIndex === index }"
+               @click.stop="handleVoterClick($event, index)"
+               :class="{ 'dragging': draggedIndex === index, 'constraint': (selectedVoters.includes(index) && !isPeer) || (isPeer && allowedVoters && !allowedVoters.includes(index)) }"
           >
             <div class="voter-info">
               <input
                 type="text"
                 class="voter-name"
-                x-model="voter.name"
+                :value="editMode || voter.name ? voter.name : 'Voter ' + (index + 1)"
+                @input="voter.name = $event.target.value"
                 @keydown.enter="$event.target.blur()"
                 @blur="saveData()"
-                placeholder="Voter name"
+                :placeholder="editMode ? 'Voter name' : ''"
                 :readonly="!editMode"
                 :style="!editMode ? 'cursor: default;' : ''"
               >
               <input
                 type="number"
                 class="voter-count"
+                x-show="editMode || showCounts()"
                 x-model.number="voter.count"
                 @keydown.enter="$event.target.blur()"
                 @blur="saveData()"
@@ -506,7 +542,7 @@
       </div>
     </div>
 
-    <div class="totals" x-show="!editMode">
+    <div class="totals" x-show="!editMode" :class="{ 'selection-active': selectedVoters.length > 0 && !isPeer }">
       <div class="total-item yeah">
         <div class="total-label">Yeah</div>
         <div class="total-value" x-text="getTotalByVote('yeah')"></div>
@@ -530,6 +566,8 @@
         editMode: true, // Start with edit mode enabled
         showCoffeeBanner: true, // Control visibility of the coffee banner
         draggedIndex: null, // Track which voter is being dragged
+        selectedVoters: [], // Selected voters for link generation
+        allowedVoters: null, // Voting restriction when joining via link
 
         // WebRTC properties
         peer: null,
@@ -564,6 +602,7 @@
               // Update previousGroupTitle to match
               this.previousGroupTitle = this.groupTitle;
               this.masterId = votingConfig.masterId;
+              this.allowedVoters = votingConfig.allowedVoters || null;
 
               // Initialize peer connection
               this.initPeer(true);
@@ -827,6 +866,9 @@
             groupTitle: this.groupTitle,
             masterId: this.peerId
           };
+          if (this.selectedVoters.length > 0) {
+            votingConfig.allowedVoters = this.selectedVoters;
+          }
 
           // Encode the configuration
           const encodedConfig = btoa(JSON.stringify(votingConfig));
@@ -852,9 +894,9 @@
             });
         },
 
-        normalInit(groupParam) {
-          if (groupParam) {
-            this.groupTitle = decodeURIComponent(groupParam);
+       normalInit(groupParam) {
+         if (groupParam) {
+           this.groupTitle = decodeURIComponent(groupParam);
             // Update previousGroupTitle to match
             this.previousGroupTitle = this.groupTitle;
             this.loadData();
@@ -873,9 +915,11 @@
             this.previousGroupTitle = this.groupTitle;
             this.updateGroupTitle();
             // If no voting group, default to edit enabled
-            this.editMode = true;
-          }
-        },
+           this.editMode = true;
+         }
+          // Clear any voting restrictions
+          this.allowedVoters = null;
+       },
 
         // Store the previous title to check for changes
         previousGroupTitle: '',
@@ -938,7 +982,28 @@
           }
         },
 
+        handleVoterClick(event, index) {
+          if (this.editMode || this.isPeer) return;
+          if (event.target.closest('.vote-option')) return;
+          if (this.selectedVoters.includes(index)) {
+            this.selectedVoters = this.selectedVoters.filter(i => i !== index);
+          } else {
+            this.selectedVoters.push(index);
+          }
+        },
+
+        clearSelection() {
+          this.selectedVoters = [];
+        },
+
+        showCounts() {
+          return this.voters.some(v => v.count !== 1);
+        },
+
         setVote(index, vote) {
+          if (this.isPeer && this.allowedVoters && !this.allowedVoters.includes(index)) {
+            return;
+          }
           this.voters[index].vote = vote;
           this.saveData();
 
@@ -962,11 +1027,20 @@
           }
         },
 
-        getTotalByVote(voteType) {
-          return this.voters
-            .filter(voter => voter.vote === voteType)
+       getTotalByVote(voteType) {
+          let indexes;
+          if (this.isPeer && this.allowedVoters && this.allowedVoters.length > 0) {
+            indexes = this.allowedVoters;
+          } else if (!this.isPeer && this.selectedVoters.length > 0) {
+            indexes = this.selectedVoters;
+          } else {
+            indexes = this.voters.map((_, i) => i);
+          }
+          return indexes
+            .map(i => this.voters[i])
+            .filter(voter => voter && voter.vote === voteType)
             .reduce((sum, voter) => sum + (voter.count || 0), 0);
-        },
+       },
 
         saveData() {
           if (!this.groupTitle) return;


### PR DESCRIPTION
## Summary
- refine highlight color with `--selection-color`
- accelerate color transitions for voter items
- disable focus styles in voting mode
- display default voter names in voting mode
- hide counts when everyone has one vote

## Testing
- `git status --short`
